### PR TITLE
Fix admin grids not loading

### DIFF
--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -29,13 +29,6 @@
             <argument name="resourceModel" xsi:type="string">Encomage\StoreLocator\Model\ResourceModel\Marker</argument>
         </arguments>
     </type>
-    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
-        <arguments>
-            <argument name="collections" xsi:type="array">
-                <item name="markers_grid_data_source" xsi:type="string">Encomage\StoreLocator\Model\ResourceModel\Marker\Grid\Collection</item>
-            </argument>
-        </arguments>
-    </type>
     <type name="Magento\Framework\View\Page\Config\Generator\Head">
         <plugin name="storelocator-generator-head" type="Encomage\StoreLocator\Plugin\View\Page\Config\Generator\Head"/>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -14,4 +14,11 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
+        <arguments>
+            <argument name="collections" xsi:type="array">
+                <item name="markers_grid_data_source" xsi:type="string">Encomage\StoreLocator\Model\ResourceModel\Marker\Grid\Collection</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
- Fix admin grids unable to locate data source collections

<img width="626" alt="encomage_storelocator_admin_grids_broken" src="https://user-images.githubusercontent.com/1231423/92648734-beea4480-f29e-11ea-95ca-1eb36f6e2ed0.png">
